### PR TITLE
Add user DTOs and service contract

### DIFF
--- a/ImageLinks.Application/DTOs/Users/CreateUserRequest.cs
+++ b/ImageLinks.Application/DTOs/Users/CreateUserRequest.cs
@@ -1,0 +1,6 @@
+namespace ImageLinks.Application.DTOs.Users;
+
+public sealed record CreateUserRequest(
+    int? Rec_ID,
+    string User_Name,
+    string Password);

--- a/ImageLinks.Application/DTOs/Users/UpdateUserRequest.cs
+++ b/ImageLinks.Application/DTOs/Users/UpdateUserRequest.cs
@@ -1,0 +1,6 @@
+namespace ImageLinks.Application.DTOs.Users;
+
+public sealed record UpdateUserRequest(
+    int Rec_ID,
+    string User_Name,
+    string Password);

--- a/ImageLinks.Application/DTOs/Users/UserDto.cs
+++ b/ImageLinks.Application/DTOs/Users/UserDto.cs
@@ -1,4 +1,0 @@
-﻿namespace ImageLinks.Application.DTOs.Users
-{
-    public record UserDto(string UserId);
-}

--- a/ImageLinks.Application/DTOs/Users/UserMappings.cs
+++ b/ImageLinks.Application/DTOs/Users/UserMappings.cs
@@ -1,0 +1,26 @@
+using ImageLinks.Domain.Users;
+
+namespace ImageLinks.Application.DTOs.Users;
+
+public static class UserMappings
+{
+    public static UserResponse ToUserResponse(this User user)
+        => new(user.Rec_ID, user.User_Name, user.Password);
+
+    public static User ToDomain(this CreateUserRequest request)
+        => new()
+        {
+            Rec_ID = request.Rec_ID ?? 0,
+            User_Name = request.User_Name,
+            Password = request.Password,
+        };
+
+    public static void ApplyUpdates(this UpdateUserRequest request, User user)
+    {
+        user.User_Name = request.User_Name;
+        user.Password = request.Password;
+    }
+
+    public static UpdateUserRequest ToUpdateRequest(this User user)
+        => new(user.Rec_ID, user.User_Name, user.Password);
+}

--- a/ImageLinks.Application/DTOs/Users/UserResponse.cs
+++ b/ImageLinks.Application/DTOs/Users/UserResponse.cs
@@ -1,0 +1,6 @@
+namespace ImageLinks.Application.DTOs.Users;
+
+public sealed record UserResponse(
+    int Rec_ID,
+    string User_Name,
+    string Password);

--- a/ImageLinks.Application/Interfaces/IUsersService.cs
+++ b/ImageLinks.Application/Interfaces/IUsersService.cs
@@ -1,6 +1,18 @@
-﻿namespace ImageLinks.Application.Interfaces
+using System.Collections.Generic;
+using ImageLinks.Application.DTOs.Users;
+using ImageLinks.Domain.Results;
+
+namespace ImageLinks.Application.Interfaces;
+
+public interface IUsersService
 {
-    internal interface IUsersService
-    {
-    }
+    Task<Result<IReadOnlyList<UserResponse>>> GetAllAsync(CancellationToken ct = default);
+
+    Task<Result<UserResponse>> GetByIdAsync(int recId, CancellationToken ct = default);
+
+    Task<Result<UserResponse>> CreateAsync(CreateUserRequest request, CancellationToken ct = default);
+
+    Task<Result<UserResponse>> UpdateAsync(UpdateUserRequest request, CancellationToken ct = default);
+
+    Task<Result<Deleted>> DeleteAsync(int recId, CancellationToken ct = default);
 }


### PR DESCRIPTION
## Summary
- expose the users service contract with async CRUD operations returning domain result wrappers
- introduce create, update, and response DTO records for users
- add centralized mapping extensions between user entities and DTOs

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d781ade2f0832ca3077d61d2060194