### PR TITLE
Add Dapper users service and wire up infrastructure services

### DIFF
--- a/ImageLinks.Api/ImageLinks.Api.csproj
+++ b/ImageLinks.Api/ImageLinks.Api.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ImageLinks.Application\ImageLinks.Application.csproj" />
+    <ProjectReference Include="..\ImageLinks.Infrastructure\ImageLinks.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ImageLinks.Api/Program.cs
+++ b/ImageLinks.Api/Program.cs
@@ -1,8 +1,11 @@
+using ImageLinks.Infrastructure;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 
 builder.Services.AddOpenApi();
+builder.Services.AddInfrastructureServices();
 
 var app = builder.Build();
 

--- a/ImageLinks.Api/appsettings.Development.json
+++ b/ImageLinks.Api/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Initial Catalog=ImageLinks;User ID=imagelinks_user;Password=ChangeMe123!;TrustServerCertificate=True;",
+    "MasterConnection": "Server=localhost;Initial Catalog=master;User ID=sa;Password=ChangeMe123!;TrustServerCertificate=True;"
   }
 }

--- a/ImageLinks.Api/appsettings.json
+++ b/ImageLinks.Api/appsettings.json
@@ -6,8 +6,8 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "",
-    "MasterConnection": ""
+    "DefaultConnection": "Server=localhost;Initial Catalog=ImageLinks;User ID=imagelinks_user;Password=ChangeMe123!;TrustServerCertificate=True;",
+    "MasterConnection": "Server=localhost;Initial Catalog=master;User ID=sa;Password=ChangeMe123!;TrustServerCertificate=True;"
   },
   "AllowedHosts": "*"
 }

--- a/ImageLinks.Application/Interfaces/IUsersService.cs
+++ b/ImageLinks.Application/Interfaces/IUsersService.cs
@@ -1,6 +1,31 @@
-﻿namespace ImageLinks.Application.Interfaces
+using ImageLinks.Domain.Users;
+
+namespace ImageLinks.Application.Interfaces
 {
-    internal interface IUsersService
+    public interface IUsersService
     {
+        Task<IEnumerable<User>> GetUsersAsync(
+            string? connectionString = null,
+            CancellationToken ct = default);
+
+        Task<User?> GetUserByIdAsync(
+            int recId,
+            string? connectionString = null,
+            CancellationToken ct = default);
+
+        Task<int> CreateUserAsync(
+            User user,
+            string? connectionString = null,
+            CancellationToken ct = default);
+
+        Task<bool> UpdateUserAsync(
+            User user,
+            string? connectionString = null,
+            CancellationToken ct = default);
+
+        Task<bool> DeleteUserAsync(
+            int recId,
+            string? connectionString = null,
+            CancellationToken ct = default);
     }
 }

--- a/ImageLinks.Infrastructure/DependencyInjection.cs
+++ b/ImageLinks.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,16 @@
+using ImageLinks.Application.Interfaces;
+using ImageLinks.Infrastructure.Persistence.Dapper;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ImageLinks.Infrastructure
+{
+    public static class DependencyInjection
+    {
+        public static IServiceCollection AddInfrastructureServices(this IServiceCollection services)
+        {
+            services.AddScoped<IGenericService, GenericService>();
+            services.AddScoped<IUsersService, UsersService>();
+            return services;
+        }
+    }
+}

--- a/ImageLinks.Infrastructure/Persistence/Dapper/UsersService.cs
+++ b/ImageLinks.Infrastructure/Persistence/Dapper/UsersService.cs
@@ -1,0 +1,133 @@
+using System.Data;
+using System.Linq;
+using Dapper;
+using ImageLinks.Application.Interfaces;
+using ImageLinks.Domain.Enums;
+using ImageLinks.Domain.Users;
+
+namespace ImageLinks.Infrastructure.Persistence.Dapper
+{
+    public sealed class UsersService : IUsersService
+    {
+        private const string UsersTableProjection = "REC_ID, USER_NAME, PASSWORD";
+        private readonly IGenericService _genericService;
+
+        public UsersService(IGenericService genericService)
+            => _genericService = genericService;
+
+        public async Task<IEnumerable<User>> GetUsersAsync(
+            string? connectionString = null,
+            CancellationToken ct = default)
+        {
+            var sql = $"SELECT {UsersTableProjection} FROM USERS";
+            var table = await _genericService.GetDataTableAsync(sql, null, connectionString, ct);
+            return MapUsers(table).ToArray();
+        }
+
+        public async Task<User?> GetUserByIdAsync(
+            int recId,
+            string? connectionString = null,
+            CancellationToken ct = default)
+        {
+            var provider = _genericService.GetDatabaseType(connectionString);
+            var paramPrefix = GetParameterPrefix(provider);
+            var sql = $"SELECT {UsersTableProjection} FROM USERS WHERE REC_ID = {paramPrefix}Rec_ID";
+
+            var parameters = new DynamicParameters();
+            parameters.Add("Rec_ID", recId, DbType.Int32, ParameterDirection.Input);
+
+            var table = await _genericService.GetDataTableAsync(sql, parameters, connectionString, ct);
+            return MapUsers(table).FirstOrDefault();
+        }
+
+        public async Task<int> CreateUserAsync(
+            User user,
+            string? connectionString = null,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+
+            var provider = _genericService.GetDatabaseType(connectionString);
+            var paramPrefix = GetParameterPrefix(provider);
+
+            var parameters = new DynamicParameters();
+            parameters.Add("User_Name", user.User_Name, DbType.String, ParameterDirection.Input);
+            parameters.Add("Password", user.Password, DbType.String, ParameterDirection.Input);
+            parameters.Add("Rec_ID", dbType: DbType.Int32, direction: ParameterDirection.Output);
+
+            var sql = provider switch
+            {
+                DatabaseProvider.Oracle => $@"
+BEGIN
+    INSERT INTO USERS (REC_ID, USER_NAME, PASSWORD)
+    VALUES ((SELECT NVL(MAX(REC_ID), 0) + 1 FROM USERS), {paramPrefix}User_Name, {paramPrefix}Password)
+    RETURNING REC_ID INTO {paramPrefix}Rec_ID;
+END;",
+                _ => $@"
+INSERT INTO USERS (User_Name, Password)
+VALUES ({paramPrefix}User_Name, {paramPrefix}Password);
+SET {paramPrefix}Rec_ID = CAST(SCOPE_IDENTITY() AS INT);"
+            };
+
+            await _genericService.ExecuteNonQueryAsync(sql, parameters, connectionString, ct);
+            return parameters.Get<int?>("Rec_ID") ?? 0;
+        }
+
+        public async Task<bool> UpdateUserAsync(
+            User user,
+            string? connectionString = null,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(user);
+
+            var provider = _genericService.GetDatabaseType(connectionString);
+            var paramPrefix = GetParameterPrefix(provider);
+
+            var sql = $@"UPDATE USERS
+SET USER_NAME = {paramPrefix}User_Name,
+    PASSWORD = {paramPrefix}Password
+WHERE REC_ID = {paramPrefix}Rec_ID";
+
+            var parameters = new DynamicParameters();
+            parameters.Add("User_Name", user.User_Name, DbType.String, ParameterDirection.Input);
+            parameters.Add("Password", user.Password, DbType.String, ParameterDirection.Input);
+            parameters.Add("Rec_ID", user.Rec_ID, DbType.Int32, ParameterDirection.Input);
+
+            var affected = await _genericService.ExecuteNonQueryAsync(sql, parameters, connectionString, ct);
+            return affected > 0;
+        }
+
+        public async Task<bool> DeleteUserAsync(
+            int recId,
+            string? connectionString = null,
+            CancellationToken ct = default)
+        {
+            var provider = _genericService.GetDatabaseType(connectionString);
+            var paramPrefix = GetParameterPrefix(provider);
+
+            var sql = $"DELETE FROM USERS WHERE REC_ID = {paramPrefix}Rec_ID";
+
+            var parameters = new DynamicParameters();
+            parameters.Add("Rec_ID", recId, DbType.Int32, ParameterDirection.Input);
+
+            var affected = await _genericService.ExecuteNonQueryAsync(sql, parameters, connectionString, ct);
+            return affected > 0;
+        }
+
+        private static string GetParameterPrefix(DatabaseProvider provider)
+            => provider == DatabaseProvider.Oracle ? ":" : "@";
+
+        private static IEnumerable<User> MapUsers(DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                yield return new User
+                {
+                    Rec_ID = Convert.ToInt32(row["REC_ID"]),
+                    User_Name = row.Field<string?>("USER_NAME") ?? string.Empty,
+                    Password = row.Field<string?>("PASSWORD") ?? string.Empty,
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand the users service interface with CRUD operations and exposure through DI
- implement a Dapper-backed users service that uses the generic service for SQL/PL-SQL with output parameters
- register infrastructure services for dependency injection and add concrete connection strings for the API

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7869d479c832ca4c23158d7ed485a